### PR TITLE
used copy GIF link instead of the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ improve!
 
 ### Ian
 
-![It's Wednesday My Dudes gif](https://giphy.com/clips/plusQA-test-partner-1iemyTrXywCBcE8WOi.gif)
+![It's Wednesday My Dudes gif](https://media.giphy.com/media/dvDCHPFnxnYubsrNvl/giphy.gif)
 
 ### Mitch
 


### PR DESCRIPTION
Was previously using the URL to try to get the GIF to show up, used the copy GIF link instead this time.